### PR TITLE
Fix bug in $OWNER_ID check

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,7 +24,7 @@ if [ "$1" == '/usr/sbin/sshd' ]; then
   fi
 
   # Grab UID of owner of sftp home directory
-  if [ -z OWNER_ID ]; then
+  if [ -z $OWNER_ID ]; then
     OWNER_ID=$(stat -c '%u' $FOLDER)
   fi
 


### PR DESCRIPTION
A typo (a missing $) causes (among other things) the usermod command to fail